### PR TITLE
Fix AE2 Recipes using Wireless Receiver

### DIFF
--- a/data/applied_energistics_2/versions/rv1-stable-1/mod-version.cg
+++ b/data/applied_energistics_2/versions/rv1-stable-1/mod-version.cg
@@ -752,7 +752,7 @@ group: Storage System Blocks & Parts
 
     item: ME Wireless Access Point
         recipe:
-            input: Calculation Processor, ME Glass Cable, Wireless Reciever
+            input: Calculation Processor, ME Glass Cable, Wireless Receiver
             pattern: .2. .0. .1.
             tools: Crafting Table
 
@@ -945,7 +945,7 @@ group: Tools
 
     item: Wireless Terminal
         recipe:
-            input: Dense Energy Cell, ME Terminal, Wireless Reciever
+            input: Dense Energy Cell, ME Terminal, Wireless Receiver
             pattern: .2. .1. .0.
             tools: Crafting Table
 


### PR DESCRIPTION
FIXED: Misspelling receiver causes item to display as missing in recipes
