### PR TITLE
Add Logistics Pipes + ComputerCraft support

### DIFF
--- a/data/logistics_pipes/versions/0.9.3.100/mod-version.cg
+++ b/data/logistics_pipes/versions/0.9.3.100/mod-version.cg
@@ -654,6 +654,20 @@ group: Modules
             input: Air Shard, Blank Module, Iron Chipset, Redstone
             pattern: 020 313 030
             tools: Crafting Table
+            
+    item: CC Based QuickSort module
+        recipe:
+            input: Redstone, Redstone Torch, Wireless Modem, QuickSort Module, Wired Modem, Networking Cable
+            pattern: 010 234 050
+            onlyIf: mod ComputerCraft
+            tools: Crafting Table
+            
+    item: CC Based ItemSink module
+        recipe:
+            input: Redstone, Redstone Torch, Wireless Modem, ItemSink Module, Wired Modem, Networking Cable
+            pattern: 010 234 050
+            onlyIf: mod ComputerCraft
+            tools: Crafting Table
 
 group: Upgrades
 
@@ -827,4 +841,11 @@ group: Upgrades
             onlyIf: mod Thermal Expansion
             input: Paper, Power Transportation Upgrade, Redstone Reception Coil, Redstone Transmission Coil, Steam Dynamo
             pattern: 040 212 030
+            tools: Crafting Table
+            
+    item: CC Remote Control Upgrade
+        recipe:
+            input: Redstone, Redstone Torch, Wireless Modem, Diamond Chipset, Wired Modem, Networking Cable
+            pattern: 010 234 050
+            onlyIf: mod ComputerCraft
             tools: Crafting Table


### PR DESCRIPTION
A few things that I missed when adding the first version to the site. Apparently some items are ComputerCraft-only, which I completely missed.
